### PR TITLE
Correct copy-pasted mispelling of title

### DIFF
--- a/companies/templates/companies-create.html
+++ b/companies/templates/companies-create.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}
+{% block tabtitle %} {{ title }} {% endblock tabtitle %}
 
 {% block content %}
 	

--- a/companies/templates/companies-delete.html
+++ b/companies/templates/companies-delete.html
@@ -2,10 +2,10 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>{{ tittle }}</title>
+    <title>{{ title }}</title>
 </head>
 <body>
-    <h1>{{ tittle }}</h1>
+    <h1>{{ title }}</h1>
 
     <form method='POST' action=''>{% csrf_token %}
     {{form.as_p}}

--- a/companies/templates/companies-edit.html
+++ b/companies/templates/companies-edit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}
+{% block tabtitle %} {{ title }} {% endblock tabtitle %}
 
 {% block content %}
 	

--- a/companies/templates/home-companies.html
+++ b/companies/templates/home-companies.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}
+{% block tabtitle %} {{ title }} {% endblock tabtitle %}
 
 {% block content %}
 	

--- a/home/templates/getinvolved.html
+++ b/home/templates/getinvolved.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{#{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}#}
+{#{% block tabtitle %} {{ title }} {% endblock tabtitle %}#}
 
 {% load staticfiles %}
 

--- a/jobs/templates/home-jobs.html
+++ b/jobs/templates/home-jobs.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{#{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}#}
+{#{% block tabtitle %} {{ title }} {% endblock tabtitle %}#}
 
 {% load staticfiles %}
 

--- a/pdpdmeetup/templates/home.html
+++ b/pdpdmeetup/templates/home.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{#{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}#}
+{#{% block tabtitle %} {{ title }} {% endblock tabtitle %}#}
 
 {% load staticfiles %}
 

--- a/sponsors/templates/home-sponsors.html
+++ b/sponsors/templates/home-sponsors.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{#{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}#}
+{#{% block tabtitle %} {{ title }} {% endblock tabtitle %}#}
 
 {% load staticfiles %}
 

--- a/talks/templates/home-talks.html
+++ b/talks/templates/home-talks.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{#{% block tabtitle %} {{ tittle }} {% endblock tabtitle %}#}
+{#{% block tabtitle %} {{ title }} {% endblock tabtitle %}#}
 
 {% load staticfiles %}
 


### PR DESCRIPTION
(this was causing a fair few pages to just have blank titles in browser tabs)